### PR TITLE
update to OpenCPN 5.1.5.510 and GTK3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,11 @@
 ##---------------------------------------------------------------------------
 
 # define minimum cmake version
-CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
+cmake_minimum_required(VERSION 3.4)
+project(seabots_pi VERSION 0.3)
 
 find_package(Rock)
-rock_init(seabots_pi 0.3)
+rock_init()
 SET(PACKAGE_NAME seabots_pi)
 SET(VERBOSE_NAME SeaBots)
 SET(TITLE_NAME SeaBots)

--- a/manifest.xml
+++ b/manifest.xml
@@ -5,7 +5,7 @@
   <author>Sylvain Joyeux/sylvain.joyeux@tidewise.io</author>
   <license>Proprietary</license>
 
-  <depend package="wx-gtk2" />
+  <depend package="wx-gtk3" />
   <depend package="bzip2" />
 
   <depend package="base/cmake" />


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/tidewise/tidewise.common-package_set/pull/33

Needed for Ubuntu 20.04, and should be harmless on Ubuntu 18.04